### PR TITLE
✨ Feature - MyPage View

### DIFF
--- a/client/app/src/Router.tsx
+++ b/client/app/src/Router.tsx
@@ -11,24 +11,21 @@ import QnA from "@/pages/Question/QuestionList";
 import QuestionWrite from "@/pages/Question/QuestionWrite";
 import QuestionDetail from "@/pages/Question/QuestionDetail";
 
-
 export default function Router() {
-
-
     return (
         <Routes>
-            <Route path='/' element={<Entry />} />
-            <Route path='/home' element={<Home />} />
-            <Route path='/login' element={<LogIn />} />
+            <Route path='/entry' element={<Entry />} />
+            <Route path='/' element={<LogIn />} />
             <Route path='/signup' element={<SignUp />}>
                 <Route index element={<SignUpBody />} />
                 <Route path='uploadDoc' element={<UploadDoc />} />
             </Route>
+            <Route path='/home' element={<Home />} />
             <Route path='/register' element={<Register />} />
             <Route path='/myPage' element={<MyPage />} />
             <Route path='/question' element={<QnA />} />
-            <Route path='/question/write' element={<QuestionWrite/>} />
-            <Route path='/question/:id' element={<QuestionDetail/>} />
+            <Route path='/question/write' element={<QuestionWrite />} />
+            <Route path='/question/:id' element={<QuestionDetail />} />
         </Routes>
     );
 }

--- a/client/app/src/components/Login/LoginBody/index.tsx
+++ b/client/app/src/components/Login/LoginBody/index.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable react-hooks/rules-of-hooks */
 import { useState } from "react";
 import * as Styled from "./style.ts";
 import H4 from "@/components/Common/Font/Heading/H4/index.tsx";
 import H6 from "@/components/Common/Font/Heading/H6/index.tsx";
 import { useNavigate } from "react-router-dom";
+import { convertKoreanToEnglish } from "@/utils/convertKoreanToEnglish.ts";
 
 export default function LoginBody() {
     const navigate = useNavigate();
@@ -11,27 +11,39 @@ export default function LoginBody() {
     const [showPassword, setShowPassword] = useState(false);
     const [ID, setID] = useState("");
     const [password, setPassword] = useState("");
+    const isLoginDisabled = ID === "" || password === "";
 
     function handleLoginClick() {
-        alert("Login Button Clicked");
+        console.log(ID, password);
+        navigate("/home");
     }
 
     function handleSignUpClick() {
         navigate("/signup");
     }
 
+    const handleIDChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const convertedValue = convertKoreanToEnglish(e.target.value);
+        setID(convertedValue);
+    };
+
+    const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const convertedValue = convertKoreanToEnglish(e.target.value);
+        setPassword(convertedValue);
+    };
+
     return (
         <Styled.Container>
             <Styled.InputContainer>
                 <Styled.Wrapper>
-                    <Styled.Input type='text' placeholder='아이디' value={ID} onChange={(e) => setID(e.target.value)} />
+                    <Styled.Input type='text' placeholder='아이디' value={ID} onChange={handleIDChange} />
                 </Styled.Wrapper>
                 <Styled.Wrapper>
                     <Styled.Input
                         type={showPassword ? "text" : "password"}
                         placeholder='비밀번호'
                         value={password}
-                        onChange={(e) => setPassword(e.target.value)}
+                        onChange={handlePasswordChange}
                     />
                     <Styled.ShowPasswordButton onClick={() => setShowPassword(!showPassword)}>
                         {showPassword ? "Hide" : "Show"}
@@ -39,7 +51,7 @@ export default function LoginBody() {
                 </Styled.Wrapper>
             </Styled.InputContainer>
             <Styled.ButtonContainer>
-                <Styled.LoginButton onClick={handleLoginClick}>
+                <Styled.LoginButton disabled={isLoginDisabled} onClick={handleLoginClick} isDisabled={isLoginDisabled}>
                     <H4 text='로그인 하기' />
                 </Styled.LoginButton>
             </Styled.ButtonContainer>

--- a/client/app/src/components/Login/LoginBody/style.ts
+++ b/client/app/src/components/Login/LoginBody/style.ts
@@ -58,20 +58,27 @@ export const ButtonContainer = styled.div`
     margin-top: 10px;
 `;
 
-export const LoginButton = styled.button`
+export const LoginButton = styled.button<{ isDisabled: boolean }>`
     width: 80%;
     height: 50px;
+    background-color: ${(props) => (props.isDisabled ? "#ccc" : "#fff")};
+    color: ${(props) => (props.isDisabled ? "#666" : "white")};
     border: 1px solid #ccc;
-    background-color: #fff;
     border-radius: 25px;
-    cursor: pointer;
+    cursor: ${(props) => (props.isDisabled ? "not-allowed" : "pointer")};
+    opacity: ${(props) => (props.isDisabled ? 0.5 : 1)};
+    transition: background-color 0.3s, color 0.3s;
+
+    &:hover {
+        background-color: ${(props) => (props.isDisabled ? "#ccc" : "#fff")};
+    }
 `;
 
 export const SignUpContainer = styled.div`
     width: 100%;
     display: flex;
     justify-content: center;
-    margin-top: 30px;
+    margin-top: 25px;
     align-items: column;
 `;
 

--- a/client/app/src/components/Login/LoginHeader/index.tsx
+++ b/client/app/src/components/Login/LoginHeader/index.tsx
@@ -1,23 +1,10 @@
 import * as Styled from "./style.ts";
-import Home from "@/assets/icons/Home.svg";
 import H1 from "@/components/Common/Font/Heading/H1/index.tsx";
-import SvgButton from "@/components/Common/SvgButton";
-import { useNavigate } from "react-router-dom";
 
 export default function LoginHeader() {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const navigate = useNavigate();
-
-    const handleHomeClick = () => {
-        navigate("/home");
-    };
-
     return (
         <Styled.Container>
             <H1 text='로그인' />
-            <Styled.RightButton>
-                <SvgButton src={Home} height={"32px"} width={"32px"} onClick={handleHomeClick} />
-            </Styled.RightButton>
         </Styled.Container>
     );
 }

--- a/client/app/src/components/Login/LoginHeader/style.ts
+++ b/client/app/src/components/Login/LoginHeader/style.ts
@@ -1,16 +1,11 @@
 import styled from "styled-components";
 
 export const Container = styled.div`
-    padding-top: 10px;
+    padding-top: 50px;
     width: 100%;
     height: 7vh;
     position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
-`;
-
-export const RightButton = styled.div`
-    position: absolute;
-    right: 40px;
 `;

--- a/client/app/src/components/MyPage/MyPageBody/index.tsx
+++ b/client/app/src/components/MyPage/MyPageBody/index.tsx
@@ -1,0 +1,341 @@
+import React, { useEffect, useState } from "react";
+import * as Styled from "./style.ts";
+import Avatar from "@/assets/icons/Avatar.svg";
+import H2 from "@/components/Common/Font/Heading/H2/index.tsx";
+import H5 from "@/components/Common/Font/Heading/H5";
+import { useNavigate } from "react-router-dom";
+
+function MyPageBody() {
+    const navigate = useNavigate();
+
+    const [profileImage, setProfileImage] = useState<string>(Avatar);
+    const [apartmentName, setApartmentName] = useState<string>("현재 사용자의 아파트");
+    const [userName, setUserName] = useState<string>("홍길동");
+    const [userEmail, setUserEmail] = useState<string>("xxxxxx@xxx.com");
+    const [defectCount, setDefectCount] = useState<number>(0);
+    const [qnaList, setQnaList] = useState<{ id: number; title: string; comments: number }[]>([
+        { id: 1, title: "제목 1", comments: 0 },
+        { id: 2, title: "제목 2", comments: 0 },
+        { id: 3, title: "제목 3", comments: 0 },
+        { id: 4, title: "제목 4", comments: 0 },
+        { id: 5, title: "제목 5", comments: 0 },
+    ]);
+
+    const [isDocumentUploaded, setIsDocumentUploaded] = useState<boolean>(false);
+    const [openSection, setOpenSection] = useState<number | null>(null);
+
+    const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) {
+            const imageUrl = URL.createObjectURL(file);
+            setProfileImage(imageUrl);
+        }
+    };
+
+    const handleDefectButtonClick = () => {
+        alert("신청한 하자 조회 버튼 클릭");
+        // navigate("/하자 조회 페이지");
+    };
+
+    const handleQnaClick = (id: number) => {
+        alert(`게시글 ${id}번으로 이동`);
+        // navigate(`/question/${id}`);
+    };
+
+    const handleUploadClick = () => {
+        alert("인증 서류 업로드 화면으로 이동");
+        navigate("/signup/uploadDoc"); // 인증 서류 업로드 페이지로 이동
+    };
+
+    const toggleSection = (section: number) => {
+        setOpenSection(openSection === section ? null : section);
+    };
+
+    const handleContainerClick = (section: number) => (event: React.MouseEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        toggleSection(section);
+    };
+
+    const handleLogoutClick = () => {
+        alert("로그아웃 버튼 클릭");
+        navigate("/");
+    };
+
+    useEffect(() => {
+        setProfileImage(Avatar);
+        setUserName("김테스트");
+        setUserEmail("test@test.com");
+        setApartmentName("한남더힐");
+        setDefectCount(3);
+        setQnaList([
+            { id: 1, title: "제목 1", comments: 0 },
+            { id: 2, title: "제목 2", comments: 0 },
+            { id: 3, title: "제목 3", comments: 0 },
+            { id: 4, title: "제목 4", comments: 0 },
+            { id: 5, title: "제목 5", comments: 0 },
+            { id: 6, title: "제목 6", comments: 0 },
+            { id: 7, title: "제목 7", comments: 0 },
+        ]);
+        setIsDocumentUploaded(false);
+    }, []);
+
+    return (
+        <Styled.Container>
+            <Styled.UserSection>
+                <Styled.LineWrapper>
+                    <Styled.HorizontalLine />
+                    <Styled.UserImageWrapper>
+                        <Styled.UserImage>
+                            <Styled.ProfileImage src={profileImage} alt='Profile' />
+                            <Styled.ChangeText>
+                                <label htmlFor='file-input'>사진 변경</label>
+                            </Styled.ChangeText>
+                        </Styled.UserImage>
+                    </Styled.UserImageWrapper>
+                    <Styled.HorizontalLine />
+                </Styled.LineWrapper>
+                <Styled.FileInput id='file-input' type='file' accept='image/*' onChange={handleImageChange} />
+                <Styled.UserLabel>
+                    <Styled.UserText>
+                        <H2 text={userName} />
+                    </Styled.UserText>
+                    <Styled.UserText>
+                        <H5 text={userEmail} />
+                    </Styled.UserText>
+                </Styled.UserLabel>
+            </Styled.UserSection>
+            <Styled.InfoSection>
+                <Styled.ApartNameSection>
+                    <Styled.LabelWithLine>입주 예정 아파트</Styled.LabelWithLine>
+                    <Styled.CommonWrapper>
+                        <Styled.ApartNameWrapper>
+                            {!isDocumentUploaded ? (
+                                <Styled.ApartNameText isUploaded={isDocumentUploaded}>
+                                    아직 인증 서류가 확인되지 않았습니다.
+                                </Styled.ApartNameText>
+                            ) : (
+                                <Styled.ApartNameText isUploaded={isDocumentUploaded}>
+                                    {apartmentName}
+                                </Styled.ApartNameText>
+                            )}
+
+                            {!isDocumentUploaded && (
+                                <Styled.UploadButton onClick={handleUploadClick}>인증 서류 업로드</Styled.UploadButton>
+                            )}
+                        </Styled.ApartNameWrapper>
+                    </Styled.CommonWrapper>
+                </Styled.ApartNameSection>
+
+                <Styled.DefectSection>
+                    <Styled.LabelWithLine>현재 신청한 하자</Styled.LabelWithLine>
+                    <Styled.CommonWrapperNoBorder>
+                        <Styled.DefectInfo>
+                            <Styled.CountLabel>현재 신청한 하자 갯수 : {defectCount}개</Styled.CountLabel>
+                            <Styled.DefectButton onClick={handleDefectButtonClick}>
+                                신청한 하자 조회
+                            </Styled.DefectButton>
+                        </Styled.DefectInfo>
+                    </Styled.CommonWrapperNoBorder>
+                </Styled.DefectSection>
+
+                <Styled.QnASection>
+                    <Styled.LabelWithLine>작성한 Q&A 게시글</Styled.LabelWithLine>
+                    <Styled.CommonWrapperColumn>
+                        <Styled.CountLabel>현재 작성한 게시글 수 : {qnaList.length}개</Styled.CountLabel>
+                        <Styled.QnAWrapper>
+                            {qnaList.map((qna) => (
+                                <Styled.QnAItem key={qna.id} onClick={() => handleQnaClick(qna.id)}>
+                                    <Styled.QnATitle>{qna.title}</Styled.QnATitle>
+                                    <Styled.QnAComments>댓글 {qna.comments}</Styled.QnAComments>
+                                </Styled.QnAItem>
+                            ))}
+                        </Styled.QnAWrapper>
+                    </Styled.CommonWrapperColumn>
+                </Styled.QnASection>
+            </Styled.InfoSection>
+
+            <Styled.RuleDescriptionContainer>
+                <Styled.LabelWithLine>이용약관 안내</Styled.LabelWithLine>
+
+                <Styled.TermsContainer onClick={handleContainerClick(1)}>
+                    <Styled.SectionHeader>
+                        1. 수집하는 개인정보 항목
+                        <Styled.ToggleButton>{openSection === 1 ? "▲" : "▼"}</Styled.ToggleButton>
+                    </Styled.SectionHeader>
+                    {openSection === 1 && (
+                        <Styled.TermsContent>
+                            본 애플리케이션은 회원가입, 고객상담, 서비스 신청 등 원활한 서비스 제공을 위해 아래와 같은
+                            개인정보를 수집하고 있습니다.
+                            <ul>
+                                <li>필수 항목: 이름, 이메일 주소, 비밀번호, 연락처(전화번호)</li>
+                                <li>선택 항목: 생년월일, 성별, 주소</li>
+                                <li>자동 수집 항목: IP 주소, 쿠키, 방문 기록, 서비스 이용 기록 등</li>
+                            </ul>
+                        </Styled.TermsContent>
+                    )}
+                </Styled.TermsContainer>
+
+                <Styled.TermsContainer onClick={handleContainerClick(2)}>
+                    <Styled.SectionHeader>
+                        2. 개인정보의 수집 및 이용 목적
+                        <Styled.ToggleButton>{openSection === 2 ? "▲" : "▼"}</Styled.ToggleButton>
+                    </Styled.SectionHeader>
+                    {openSection === 2 && (
+                        <Styled.TermsContent>
+                            본 애플리케이션은 수집한 개인정보를 다음의 목적을 위해 활용합니다.
+                            <ul>
+                                <li>서비스 제공 및 운영: 회원관리, 서비스 제공, 콘텐츠 제공, 본인인증, 연령 확인</li>
+                                <li>고객 관리: 민원 처리, 공지사항 전달</li>
+                                <li>마케팅 및 광고: 이벤트 정보 제공, 맞춤형 광고 제공</li>
+                            </ul>
+                        </Styled.TermsContent>
+                    )}
+                </Styled.TermsContainer>
+
+                <Styled.TermsContainer onClick={handleContainerClick(3)}>
+                    <Styled.SectionHeader>
+                        3. 개인정보의 보유 및 이용 기간
+                        <Styled.ToggleButton>{openSection === 3 ? "▲" : "▼"}</Styled.ToggleButton>
+                    </Styled.SectionHeader>
+                    {openSection === 3 && (
+                        <Styled.TermsContent>
+                            원칙적으로, 개인정보의 수집 및 이용 목적이 달성된 후에는 해당 정보를 지체 없이 파기합니다.
+                            다만, 다음의 정보에 대해서는 아래의 이유로 명시한 기간 동안 보존합니다.
+                            <ul>
+                                <li>관련 법령에 의한 보존 정보</li>
+                                <li>
+                                    계약 또는 청약철회 등에 관한 기록: 5년 (전자상거래 등에서의 소비자보호에 관한 법률)
+                                </li>
+                                <li>
+                                    소비자의 불만 또는 분쟁처리에 관한 기록: 3년 (전자상거래 등에서의 소비자보호에 관한
+                                    법률)
+                                </li>
+                                <li>로그 기록: 3개월 (통신비밀보호법)</li>
+                            </ul>
+                        </Styled.TermsContent>
+                    )}
+                </Styled.TermsContainer>
+
+                <Styled.TermsContainer onClick={handleContainerClick(4)}>
+                    <Styled.SectionHeader>
+                        4. 개인정보의 제3자 제공
+                        <Styled.ToggleButton>{openSection === 4 ? "▲" : "▼"}</Styled.ToggleButton>
+                    </Styled.SectionHeader>
+                    {openSection === 4 && (
+                        <Styled.TermsContent>
+                            본 애플리케이션은 사용자의 동의 없이는 원칙적으로 개인정보를 외부에 제공하지 않습니다. 다만,
+                            아래의 경우는 예외로 합니다.
+                            <ul>
+                                <li>사용자가 사전에 동의한 경우</li>
+                                <li>
+                                    법령의 규정에 의하거나, 수사 목적으로 법령에 정해진 절차와 방법에 따라 수사기관의
+                                    요구가 있는 경우
+                                </li>
+                            </ul>
+                        </Styled.TermsContent>
+                    )}
+                </Styled.TermsContainer>
+
+                <Styled.TermsContainer onClick={handleContainerClick(5)}>
+                    <Styled.SectionHeader>
+                        5. 개인정보의 파기 절차 및 방법
+                        <Styled.ToggleButton>{openSection === 5 ? "▲" : "▼"}</Styled.ToggleButton>
+                    </Styled.SectionHeader>
+                    {openSection === 5 && (
+                        <Styled.TermsContent>
+                            본 애플리케이션은 원칙적으로 개인정보 처리 목적이 달성된 경우에는 지체 없이 해당 개인정보를
+                            파기합니다. 파기 절차 및 방법은 다음과 같습니다.
+                            <ul>
+                                <li>
+                                    파기 절차: 사용자가 입력한 정보는 목적 달성 후 별도의 DB로 옮겨져 내부 방침 및 기타
+                                    관련 법령에 따라 일정 기간 저장된 후 파기됩니다.
+                                </li>
+                                <li>
+                                    파기 방법: 전자적 파일 형태로 저장된 개인정보는 복구할 수 없는 기술적 방법을
+                                    사용하여 삭제하며, 종이로 출력된 개인정보는 분쇄기로 분쇄하거나 소각하여 파기합니다.
+                                </li>
+                            </ul>
+                        </Styled.TermsContent>
+                    )}
+                </Styled.TermsContainer>
+
+                <Styled.TermsContainer onClick={handleContainerClick(6)}>
+                    <Styled.SectionHeader>
+                        6. 개인정보의 안전성 확보 조치
+                        <Styled.ToggleButton>{openSection === 6 ? "▲" : "▼"}</Styled.ToggleButton>
+                    </Styled.SectionHeader>
+                    {openSection === 6 && (
+                        <Styled.TermsContent>
+                            본 애플리케이션은 개인정보 보호를 위해 다음과 같은 안전성 확보 조치를 취하고 있습니다.
+                            <ul>
+                                <li>
+                                    개인정보 암호화: 사용자의 개인정보는 암호화되어 저장 및 관리되고 있으며, 중요한
+                                    데이터는 전송 시에도 별도의 보안 기능을 사용하고 있습니다.
+                                </li>
+                                <li>
+                                    해킹 등에 대비한 대책: 백신 프로그램을 주기적으로 업데이트하며 외부로부터 접근이
+                                    통제된 구역에 시스템을 설치하여 해킹이나 바이러스 등에 의한 개인정보 유출을 방지하고
+                                    있습니다.
+                                </li>
+                            </ul>
+                        </Styled.TermsContent>
+                    )}
+                </Styled.TermsContainer>
+
+                <Styled.TermsContainer onClick={handleContainerClick(7)}>
+                    <Styled.SectionHeader>
+                        7. 사용자 및 법정대리인의 권리와 그 행사 방법
+                        <Styled.ToggleButton>{openSection === 7 ? "▲" : "▼"}</Styled.ToggleButton>
+                    </Styled.SectionHeader>
+                    {openSection === 7 && (
+                        <Styled.TermsContent>
+                            사용자 및 법정대리인은 언제든지 등록된 자신의 개인정보를 조회하거나 수정할 수 있으며, 가입
+                            해지를 요청할 수 있습니다.
+                        </Styled.TermsContent>
+                    )}
+                </Styled.TermsContainer>
+
+                <Styled.TermsContainer onClick={handleContainerClick(8)}>
+                    <Styled.SectionHeader>
+                        8. 개인정보 보호책임자
+                        <Styled.ToggleButton>{openSection === 8 ? "▲" : "▼"}</Styled.ToggleButton>
+                    </Styled.SectionHeader>
+                    {openSection === 8 && (
+                        <Styled.TermsContent>
+                            본 애플리케이션은 사용자의 개인정보를 보호하고 개인정보와 관련한 불만을 처리하기 위하여
+                            아래와 같이 개인정보 보호책임자를 지정하고 있습니다.
+                            <ul>
+                                <li>개인정보 보호책임자</li>
+                                <li>이름: [이름]</li>
+                                <li>연락처: [전화번호]</li>
+                                <li>이메일: [이메일 주소]</li>
+                            </ul>
+                        </Styled.TermsContent>
+                    )}
+                </Styled.TermsContainer>
+
+                <Styled.TermsContainer onClick={handleContainerClick(9)}>
+                    <Styled.SectionHeader>
+                        9. 개인정보 처리방침 변경
+                        <Styled.ToggleButton>{openSection === 9 ? "▲" : "▼"}</Styled.ToggleButton>
+                    </Styled.SectionHeader>
+                    {openSection === 9 && (
+                        <Styled.TermsContent>
+                            이 개인정보 처리방침은 시행일로부터 적용되며, 법령 및 방침에 따른 변경내용의 추가, 삭제 및
+                            정정이 있는 경우에는 변경사항의 시행 7일 전부터 공지사항을 통하여 고지할 것입니다.
+                            <ul>
+                                <li>시행일: [시행일자]</li>
+                            </ul>
+                        </Styled.TermsContent>
+                    )}
+                </Styled.TermsContainer>
+            </Styled.RuleDescriptionContainer>
+
+            <Styled.LogoutSection>
+                <Styled.LogoutButton onClick={handleLogoutClick}>로그아웃</Styled.LogoutButton>
+            </Styled.LogoutSection>
+        </Styled.Container>
+    );
+}
+
+export default MyPageBody;

--- a/client/app/src/components/MyPage/MyPageBody/style.ts
+++ b/client/app/src/components/MyPage/MyPageBody/style.ts
@@ -1,0 +1,341 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+    padding-top: 10px;
+    width: 100%;
+    position: relative;
+    justify-content: center;
+    align-items: center;
+
+    -ms-overflow-style: none; // IE and Edge
+    scrollbar-width: none; // Firefox
+    &::-webkit-scrollbar {
+        display: none; // Chrome, Safari, Opera
+    }
+`;
+
+export const UserSection = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-top: 20px;
+    margin-bottom: 20px;
+`;
+
+export const LineWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    justify-content: center;
+`;
+
+export const HorizontalLine = styled.div`
+    flex-grow: 1;
+    height: 1px;
+    background-color: #ddd;
+`;
+
+export const UserImageWrapper = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0 20px;
+    margin-bottom: 20px;
+`;
+
+export const ImageLabel = styled.label`
+    cursor: pointer;
+    margin-bottom: 20px;
+`;
+
+export const UserImage = styled.div`
+    position: relative;
+    width: 125px;
+    height: 125px;
+    border-radius: 50%;
+    overflow: hidden;
+    border: 2px solid #ddd;
+    cursor: pointer;
+`;
+
+export const ProfileImage = styled.img`
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+`;
+
+export const ChangeText = styled.div`
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    padding: 10px 0;
+    background-color: rgba(0, 0, 0, 0.6);
+    color: white;
+    text-align: center;
+    font-size: 14px;
+    opacity: 0.8;
+    cursor: pointer;
+
+    label {
+        cursor: pointer;
+        color: inherit;
+        text-decoration: none;
+    }
+`;
+
+export const FileInput = styled.input`
+    display: none;
+`;
+
+export const UserText = styled.div`
+    margin: 5px;
+`;
+
+export const UserLabel = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+`;
+
+export const InfoSection = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+`;
+
+export const ApartNameSection = styled.div`
+    margin-top: 20px;
+    width: 90%;
+    margin-bottom: 80px;
+`;
+
+export const UploadButton = styled.button`
+    background-color: rgba(0, 0, 0, 0.6);
+    color: white;
+    border: none;
+    padding: 5px 10px 5px 10px;
+    border-radius: 8px;
+    cursor: pointer;
+`;
+
+export const Label = styled.div`
+    font-size: 14px;
+    color: black;
+    margin-bottom: 10px;
+    margin-left: 5px;
+`;
+
+export const LabelWithLine = styled.div`
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 10px;
+    position: relative;
+    padding-bottom: 8px;
+
+    &::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 1px;
+        background-color: #ddd;
+    }
+`;
+
+export const CommonWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border: 1px solid black;
+    border-radius: 8px;
+    padding: 15px;
+    position: relative;
+`;
+
+export const CommonWrapperNoBorder = styled(CommonWrapper)`
+    border: none;
+    padding: 0px;
+`;
+
+export const CommonWrapperColumn = styled(CommonWrapperNoBorder)`
+    margin-top: 15px;
+    flex-direction: column;
+    align-items: start;
+`;
+
+export const ApartNameWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    justify-content: space-between;
+`;
+
+export const ApartNameText = styled.div<{ isUploaded: boolean }>`
+    font-size: ${(props) => (props.isUploaded ? "16px" : "12px")};
+    font-weight: ${(props) => (props.isUploaded ? "bold" : "normal")};
+    color: black;
+`;
+
+export const DefectSection = styled.div`
+    width: 90%;
+    margin-bottom: 80px;
+`;
+
+export const DefectInfo = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+`;
+
+export const CountLabel = styled.div`
+    font-size: 16px;
+    font-weight: bold;
+    color: black;
+`;
+
+export const DefectButton = styled.button`
+    background-color: #4a4a4a;
+    color: white;
+    border-radius: 20px;
+    padding: 5px 15px;
+    font-size: 14px;
+    cursor: pointer;
+    border: none;
+    margin-left: 10px;
+
+    &:hover {
+        background-color: #333;
+    }
+`;
+
+export const QnASection = styled.div`
+    width: 90%;
+    margin-bottom: 60px;
+`;
+
+export const QnAWrapper = styled.div`
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 5px 10px 5px 10px;
+    width: 95%;
+    margin-top: 15px;
+
+    -ms-overflow-style: none; // IE and Edge
+    scrollbar-width: none; // Firefox
+    &::-webkit-scrollbar {
+        display: none; // Chrome, Safari, Opera
+    }
+`;
+
+export const QnAItem = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px;
+    border-bottom: 1px solid #ddd;
+    cursor: pointer;
+
+    &:hover {
+        background-color: #f0f0f0;
+    }
+
+    &:last-child {
+        border-bottom: none;
+    }
+`;
+
+export const QnATitle = styled.div`
+    font-size: 16px;
+    font-weight: bold;
+`;
+
+export const QnAComments = styled.div`
+    font-size: 12px;
+    color: #999;
+`;
+
+export const LogoutSection = styled.div`
+    display: flex;
+    margin-bottom: 80px;
+    justify-content: center;
+    align-items: center;
+`;
+
+export const LogoutButton = styled.button`
+    background-color: #4a4a4a;
+    color: white;
+    border-radius: 20px;
+    padding: 10px 20px;
+    font-size: 16px;
+    cursor: pointer;
+    border: none;
+
+    &:hover {
+        background-color: #333;
+    }
+`;
+
+export const RuleDescriptionContainer = styled.div`
+    padding: 20px;
+    background-color: white;
+    width: 90%;
+`;
+
+export const SectionHeader = styled.label`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+    font-size: 14px;
+`;
+
+export const ToggleButton = styled.button`
+    margin-left: auto;
+    background: none;
+    border: none;
+    font-size: 14px;
+    cursor: pointer;
+`;
+
+export const TermsContainer = styled.div`
+    margin-top: 10px;
+    margin-bottom: 10px;
+    padding: 15px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    cursor: pointer;
+`;
+
+export const TermsContent = styled.div`
+    margin-top: 10px;
+    font-size: 14px;
+    line-height: 1.5;
+    color: #555;
+`;
+
+export const CompleteButton = styled.button`
+    width: 90%;
+    height: 50px;
+    font-size: 16px;
+    color: ${({ disabled }) => (disabled ? "#aaa" : "#fff")};
+    background-color: ${({ disabled }) => (disabled ? "#ddd" : "#50555C")};
+    border: none;
+    border-radius: 5px;
+    cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
+    opacity: ${({ disabled }) => (disabled ? 0.6 : 1)};
+    transition: background-color 0.3s, color 0.3s, opacity 0.3s;
+
+    &:hover {
+        background-color: ${({ disabled }) => (disabled ? "#ddd" : "#ccc")};
+    }
+`;

--- a/client/app/src/components/MyPage/MyPageHeader/index.tsx
+++ b/client/app/src/components/MyPage/MyPageHeader/index.tsx
@@ -1,0 +1,31 @@
+import * as Styled from "./style.ts";
+import ArrowLeft from "@/assets/icons/ArrowLeft.svg";
+import Alarm from "@/assets/icons/Alarm.svg";
+import H1 from "@/components/Common/Font/Heading/H1/index.tsx";
+import SvgButton from "@/components/Common/SvgButton";
+import { useNavigate } from "react-router-dom";
+
+function MyPageHeader() {
+    const navigate = useNavigate();
+
+    const handleArrowClick = () => {
+        navigate(-1);
+    };
+
+    const handleAlarmClick = () => {
+        alert("알람 클릭");
+    };
+
+    return (
+        <Styled.Container>
+            <Styled.LeftButton>
+                <SvgButton src={ArrowLeft} height={"32px"} width={"32px"} onClick={handleArrowClick} />
+            </Styled.LeftButton>
+            <H1 text='마이페이지' />
+            <Styled.RightButton>
+                <SvgButton src={Alarm} height={"40px"} width={"40px"} onClick={handleAlarmClick} />
+            </Styled.RightButton>
+        </Styled.Container>
+    );
+}
+export default MyPageHeader;

--- a/client/app/src/components/MyPage/MyPageHeader/style.ts
+++ b/client/app/src/components/MyPage/MyPageHeader/style.ts
@@ -1,15 +1,27 @@
 import styled from "styled-components";
 
 export const Container = styled.div`
+    padding-top: 10px;
+    width: 100%;
+    height: 7vh;
+    position: relative;
     display: flex;
-    flex-direction: column;
+    justify-content: center;
     align-items: center;
-    padding: 20px;
-    justify-content: space-between;
 
     -ms-overflow-style: none; // IE and Edge
     scrollbar-width: none; // Firefox
     &::-webkit-scrollbar {
         display: none; // Chrome, Safari, Opera
     }
+`;
+
+export const LeftButton = styled.div`
+    position: absolute;
+    left: 30px;
+`;
+
+export const RightButton = styled.div`
+    position: absolute;
+    right: 30px;
 `;

--- a/client/app/src/components/SignUp/Header/index.tsx
+++ b/client/app/src/components/SignUp/Header/index.tsx
@@ -1,5 +1,6 @@
 import H1 from "@/components/Common/Font/Heading/H1";
-import H4 from "@/components/Common/Font/Heading/H4";
+import SvgButton from "@/components/Common/SvgButton/index.tsx";
+import ArrowLeft from "@/assets/icons/ArrowLeft.svg";
 import H6 from "@/components/Common/Font/Heading/H6";
 import * as Styled from "./style.ts";
 import { useNavigate } from "react-router-dom";
@@ -18,9 +19,7 @@ export default function SignUpHeader() {
     return (
         <Styled.Container>
             <Styled.LeftButton>
-                <Styled.Button onClick={handleBackClick}>
-                    <H4 text='←' />
-                </Styled.Button>
+                <SvgButton src={ArrowLeft} height={"32px"} width={"32px"} onClick={handleBackClick} />
             </Styled.LeftButton>
             <H1 text='가입 신청' />
             <Styled.RightButton>

--- a/client/app/src/components/SignUp/Header/style.ts
+++ b/client/app/src/components/SignUp/Header/style.ts
@@ -18,7 +18,7 @@ export const LeftButton = styled.div`
 export const RightButton = styled.div`
     position: absolute;
     right: 30px;
-    margin-top: 10px;
+    margin-top: 5px;
 `;
 
 export const Button = styled.button`

--- a/client/app/src/pages/MyPage/index.tsx
+++ b/client/app/src/pages/MyPage/index.tsx
@@ -1,7 +1,12 @@
+import * as Styled from "./style.ts";
+import MyPageHeader from "@/components/MyPage/MyPageHeader/index.tsx";
+import MyPageBody from "@/components/MyPage/MyPageBody/index.tsx";
+
 export default function MyPage() {
     return (
-        <div>
-        <h1>MyPage</h1>
-        </div>
+        <Styled.Container>
+            <MyPageHeader />
+            <MyPageBody />
+        </Styled.Container>
     );
 }

--- a/client/app/src/utils/convertKoreanToEnglish.ts
+++ b/client/app/src/utils/convertKoreanToEnglish.ts
@@ -1,0 +1,43 @@
+// 한글 -> 영어로 변환하는 함수
+const koreanToEnglishMap: { [key: string]: string } = {
+    ㅂ: "q",
+    ㅈ: "w",
+    ㄷ: "e",
+    ㄱ: "r",
+    ㅅ: "t",
+    ㅛ: "y",
+    ㅕ: "u",
+    ㅑ: "i",
+    ㅐ: "o",
+    ㅔ: "p",
+    ㅁ: "a",
+    ㄴ: "s",
+    ㅇ: "d",
+    ㄹ: "f",
+    ㅎ: "g",
+    ㅗ: "h",
+    ㅓ: "j",
+    ㅏ: "k",
+    ㅣ: "l",
+    ㅋ: "z",
+    ㅌ: "x",
+    ㅊ: "c",
+    ㅍ: "v",
+    ㅠ: "b",
+    ㅜ: "n",
+    ㅡ: "m",
+    ㅃ: "Q",
+    ㅉ: "W",
+    ㄸ: "E",
+    ㄲ: "R",
+    ㅆ: "T",
+    ㅒ: "O",
+    ㅖ: "P",
+};
+
+export const convertKoreanToEnglish = (value: string): string => {
+    return value
+        .split("")
+        .map((char) => koreanToEnglishMap[char] || char)
+        .join("");
+};


### PR DESCRIPTION
## 관련 이슈
- Resolves : #24 

## 작업 사항
- `MyPage` View의 구성을 완료했습니다.
- `SignUp` 부분에서 ID, PW, Email 등을 입력 받을 때 정규식 제한을 추가로 적용하였습니다.
- `utils` 폴더 내에 `convertKoreanToEnglish.ts` 파일을 추가하였습니다.
- 초기 진입 화면을 `Login` 화면으로 변경하였습니다.

## 참고 사항
- `Login` 부분에서 오른쪽 상단의 홈 버튼을 삭제하였습니다.
- `convertKoreanToEnglish.ts`의 함수는 사용자의 키보드를 매핑하여 한영 여부에 관계 없이 영어로만 입력이 되도록 합니다.
- 현재 `Login` 화면에서는 아이디, 비밀번호를 입력하고 로그인 버튼을 누르면 바로 `Home`화면으로 이동이 가능합니다.
- 기존의 `Entry` 화면은 `/entry`를 입력하여 이동이 가능합니다.
